### PR TITLE
Update overrider.rb for Rails 7.2

### DIFF
--- a/lib/rails_amp/overrider.rb
+++ b/lib/rails_amp/overrider.rb
@@ -4,7 +4,8 @@ module RailsAmp
 
     included do
       before_action do
-        RailsAmp.format = request[:format]
+        RailsAmp.format = request.params[:format]
+
         if RailsAmp.amp_renderable?(controller_path, action_name)  # default_format is :amp
           override_actions_with_rails_amp
         end


### PR DESCRIPTION
This fix will help us to work with rails 7.2, because now it causes an error because of new ActionDispatch, as I remembered, doesn't have method called `.[]` for request variable.